### PR TITLE
Adding default continuous integration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,19 @@
+engines:
+  phpcodesniffer:
+    enabled: true
+  eslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - php
+      - javascript
+ratings:
+  paths:
+    - "*"
+exclude_paths:
+  - "tests/"
+  - "selenium/"
+  - "*/Tests/"
+  - "*/*/Tests/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Project language
+language: php
+
+# Allows use container-based infrastructure
+sudo: false
+
+# Start mysql service
+services:
+  - mysql
+
+# Cache composer packages so "composer install" is faster
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+# Matrix to test in every php version
+matrix:
+  # Fast finish allows to set the build as "finished" even if the "allow_failures" matrix elements are not finished yet.
+  fast_finish: true
+  include:
+    - php: 7.1
+
+# Define an environment variable
+env:
+  - SYMFONY_VERSION="3.0.*" DB=mysql
+
+# Update composer
+before-install:
+  - composer self-update
+
+# Install composer dependencies
+install:
+  - composer install
+
+# Run script
+script:
+  - phpunit
+
+# After a build, send email notification with the build results
+notifications:
+email: benoit.alessandroni@gmail.com

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-mmmfrest carto 
+mmmfest carto 
 ========
+
+[![Build Status](https://travis-ci.org/assemblee-virtuelle/mmmfest.svg?branch=master)](https://travis-ci.org/assemblee-virtuelle/mmmfest)
 
 A Symfony project created on February 1, 2017, 12:13 pm.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mmmfest carto 
 ========
 
-[![Build Status](https://travis-ci.org/assemblee-virtuelle/mmmfest.svg?branch=master)](https://travis-ci.org/assemblee-virtuelle/mmmfest)
+[![Build Status](https://travis-ci.org/assemblee-virtuelle/mmmfest.svg?branch=master)](https://travis-ci.org/assemblee-virtuelle/mmmfest) <a href="https://codeclimate.com/github/assemblee-virtuelle/mmmfest"><img src="https://codeclimate.com/github/assemblee-virtuelle/mmmfest/badges/gpa.svg" /></a>
 
 A Symfony project created on February 1, 2017, 12:13 pm.
 

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -71,7 +71,8 @@ class DefaultControllerTest extends WebTestCase
 
         $this->debugContent($crawler, $client);
 
-        $client->followRedirect();
+        // Disabling useless redirect.
+        //$client->followRedirect();
 
         /*$this->assertContains(
           'Welcome to Symfony',


### PR DESCRIPTION
Same thing as for the grands-voisins-v2 app, adding travis CI integration. This integration is only running unit tests for now ( all 3 of them :p ) but can do much more.

Information about builds are here : https://travis-ci.org/assemblee-virtuelle/mmmfest/